### PR TITLE
feat: load txt point cloud

### DIFF
--- a/record_msg/builder.py
+++ b/record_msg/builder.py
@@ -216,7 +216,12 @@ class PointCloudBuilder(Builder):
 
     # Loads LIDAR data from binary numpy format.
     # Data is stored as (x, y, z, intensity, ring index).
-    scan = np.fromfile(file_name, dtype=np.float32)
+    if file_name.endswith('.bin'):
+      scan = np.fromfile(file_name, dtype=np.float32)
+    elif file_name.endswith('.txt'):
+      scan = np.loadtxt(file_name, dtype=np.float32)
+    else:
+      raise "Unsupported file extension."
     logging.debug(scan[:100])
 
     points = scan.reshape((-1, self._dim))[:, :4]


### PR DESCRIPTION
KITTI unsynced raw dataset stores the point cloud in txt format. This change adds the support to read point cloud in txt files.

Below is a snippet of the `2011_09_26_drive_0001_extract/velodyne_points/data/0000000000.txt`
```
74.536 9.937 2.752 0.00
74.558 10.178 2.754 0.00
74.569 10.419 2.755 0.00
74.653 10.550 2.759 0.00
74.679 10.793 2.761 0.00
74.722 11.039 2.763 0.00
70.305 10.611 2.613 0.00
74.807 11.533 2.769 0.00
74.814 11.774 2.770 0.00
74.856 12.022 2.773 0.00
```